### PR TITLE
Test admin re-config

### DIFF
--- a/pkg/bcdb/config_tx_context.go
+++ b/pkg/bcdb/config_tx_context.go
@@ -14,7 +14,7 @@ import (
 // configuration management related transactions.
 // Add, delete and update an admin record; Add, delete and update a cluster node config.
 type ConfigTxContext interface {
-	// Embed general abstraction.
+	// TxContext embeds the general abstraction.
 	TxContext
 
 	// AddAdmin add admin record.

--- a/pkg/bcdb/config_tx_context_test.go
+++ b/pkg/bcdb/config_tx_context_test.go
@@ -98,8 +98,6 @@ func TestConfigTxContext_GetClusterConfigTimeout(t *testing.T) {
 }
 
 func TestConfigTxContext_AddAdmin(t *testing.T) {
-	t.Skip("Add admin is a config update, TODO in issue: https://github.com/hyperledger-labs/orion-server/issues/148")
-
 	clientCryptoDir := testutils.GenerateTestClientCrypto(t, []string{"admin", "admin2", "server"})
 	testServer, _, _, err := SetupTestServer(t, clientCryptoDir)
 
@@ -167,8 +165,6 @@ func TestConfigTxContext_AddAdmin(t *testing.T) {
 }
 
 func TestConfigTxContext_DeleteAdmin(t *testing.T) {
-	t.Skip("Delete admin is a config update, TODO in issue: https://github.com/hyperledger-labs/orion-server/issues/148")
-
 	clientCryptoDir := testutils.GenerateTestClientCrypto(t, []string{"admin", "admin2", "admin3", "server"})
 	testServer, _, _, err := SetupTestServer(t, clientCryptoDir)
 	defer func() {
@@ -248,13 +244,11 @@ func TestConfigTxContext_DeleteAdmin(t *testing.T) {
 
 	// session1 by removed admin cannot execute additional transactions
 	tx4, err := session1.ConfigTx()
-	require.EqualError(t, err, "error handling request, server returned: status: 401 Unauthorized, message: signature verification failed")
+	require.EqualError(t, err, "error handling request, server returned: status: 401 Unauthorized, status code: 401, message: signature verification failed")
 	require.Nil(t, tx4)
 }
 
 func TestConfigTxContext_UpdateAdmin(t *testing.T) {
-	t.Skip("Update admin is a config update, TODO in issue: https://github.com/hyperledger-labs/orion-server/issues/148")
-
 	clientCryptoDir := testutils.GenerateTestClientCrypto(t, []string{"admin", "admin2", "adminUpdated", "server"})
 	testServer, _, _, err := SetupTestServer(t, clientCryptoDir)
 	defer func() {
@@ -315,7 +309,7 @@ func TestConfigTxContext_UpdateAdmin(t *testing.T) {
 
 	// session1 by updated admin cannot execute additional transactions, need to recreate session
 	tx3, err := session1.ConfigTx()
-	require.EqualError(t, err, "error handling request, server returned: status: 401 Unauthorized, message: signature verification failed")
+	require.EqualError(t, err, "error handling request, server returned: status: 401 Unauthorized, status code: 401, message: signature verification failed")
 	require.Nil(t, tx3)
 
 	// need to recreate session with new credentials


### PR DESCRIPTION
Remove the "skip" from admin re-config tests, as updating the admins is now supported by the server.

Signed-off-by: Yoav Tock <tock@il.ibm.com>