### PR TITLE
Clean code style

### DIFF
--- a/examples/academic-docs/create-dbs-users/create-dbs-users.go
+++ b/examples/academic-docs/create-dbs-users/create-dbs-users.go
@@ -13,27 +13,31 @@ import (
 )
 
 func main() {
-	fmt.Println("\n===Creating a Connection to Orion===\n")
+	fmt.Println("\n===Creating a Connection to Orion===")
+	fmt.Println()
 	db, err := util.CreateConnection()
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println("\n===Creating a Session to Orion===\n")
+	fmt.Println("\n===Creating a Session to Orion===")
+	fmt.Println()
 	session, err := util.OpenSession(db, "admin")
 	if err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println("\n===Creating a Database db1===\n")
+	fmt.Println("\n===Creating a Database db1===")
+	fmt.Println()
 	if err = createDBs(session); err != nil {
 		fmt.Println(err.Error())
 		return
 	}
 
-	fmt.Println("\n===Creating Users alice and bob===\n")
+	fmt.Println("\n===Creating Users alice and bob===")
+	fmt.Println()
 	if err = createUsers(session); err != nil {
 		fmt.Println(err.Error())
 		return


### PR DESCRIPTION
The `\n` at the end of the `Println()` is causing unit tests in the IDE to fail.

Signed-off-by: Yoav Tock <tock@il.ibm.com>