### PR TITLE
Add SetClusterConfig method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/golang/protobuf v1.5.2
-	github.com/hyperledger-labs/orion-server v0.2.1
+	github.com/hyperledger-labs/orion-server v0.2.2-0.20220201095700-5b3b3926c088
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/hyperledger-labs/orion-server v0.2.0-fix-docker.0.20220113091226-90b4
 github.com/hyperledger-labs/orion-server v0.2.0-fix-docker.0.20220113091226-90b4fe817afe/go.mod h1:PyEVhf9fKK8Euq0GDo48KBJFxS2dsZZXzcB2OH3nm7s=
 github.com/hyperledger-labs/orion-server v0.2.1 h1:uLhuSprg5EWWLs047+54f2ZGuhbZrMa/c38rqpj2FKQ=
 github.com/hyperledger-labs/orion-server v0.2.1/go.mod h1:PyEVhf9fKK8Euq0GDo48KBJFxS2dsZZXzcB2OH3nm7s=
+github.com/hyperledger-labs/orion-server v0.2.2-0.20220201095700-5b3b3926c088 h1:fubELLOvJEViGeh2MPk2k0MP/TYnzaTL+WnQrm47xJw=
+github.com/hyperledger-labs/orion-server v0.2.2-0.20220201095700-5b3b3926c088/go.mod h1:PyEVhf9fKK8Euq0GDo48KBJFxS2dsZZXzcB2OH3nm7s=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/pkg/bcdb/session.go
+++ b/pkg/bcdb/session.go
@@ -134,7 +134,9 @@ func (d *dbSession) LoadDataTx(txEnv *types.DataTxEnvelope) (LoadedDataTxContext
 	return dataTx, nil
 }
 
-// ConfigTx returns config transaction context
+// ConfigTx returns config transaction context.
+// This methods first reads the current ClusterConfig from the cluster.
+// This is only available to sessions of an admin user.
 func (d *dbSession) ConfigTx() (ConfigTxContext, error) {
 	commonCtx, err := d.newCommonTxContext()
 	if err != nil {


### PR DESCRIPTION
- Add SetClusterConfig method in order to allow the full range of config changes.
- Also UpdateCAConfig method to allow easy updates to CA config.

Raft parameters are not exposed with their own method, but they can be updated using the
SetClusterConfig method.

Signed-off-by: Yoav Tock <tock@il.ibm.com>