### PR TITLE
Full proof for tx in last block

### DIFF
--- a/pkg/bcdb/ledger.go
+++ b/pkg/bcdb/ledger.go
@@ -185,14 +185,24 @@ func (l *ledger) GetFullTxProofAndVerify(txReceipt *types.TxReceipt, lastKnownBl
 		return nil, nil, &ProofVerificationError{fmt.Sprintf("can't create proof, last known block (%d) is not same as in ledger", lastKnownBlockHeader.GetBaseHeader().GetNumber())}
 	}
 
-	pathPartOne, err := l.GetLedgerPath(GenesisBlockNumber, txBlockHeader.GetBaseHeader().GetNumber())
-	if err != nil {
-		return nil, nil, err
+	pathPartOne := &LedgerPath{
+		Path: []*types.BlockHeader{txBlockHeader},
+	}
+	if GenesisBlockNumber != txBlockHeader.GetBaseHeader().GetNumber() {
+		pathPartOne, err = l.GetLedgerPath(GenesisBlockNumber, txBlockHeader.GetBaseHeader().GetNumber())
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
-	pathPartTwo, err := l.GetLedgerPath(txBlockHeader.GetBaseHeader().GetNumber(), lastKnownBlockHeader.GetBaseHeader().GetNumber())
-	if err != nil {
-		return nil, nil, err
+	pathPartTwo := &LedgerPath{
+		Path: []*types.BlockHeader{txBlockHeader},
+	}
+	if txBlockHeader.GetBaseHeader().GetNumber() != lastKnownBlockHeader.GetBaseHeader().GetNumber() {
+		pathPartTwo, err = l.GetLedgerPath(txBlockHeader.GetBaseHeader().GetNumber(), lastKnownBlockHeader.GetBaseHeader().GetNumber())
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	txProof, err := l.GetTransactionProof(txBlockHeader.GetBaseHeader().GetNumber(), int(txReceipt.GetTxIndex()))

--- a/pkg/bcdb/proof.go
+++ b/pkg/bcdb/proof.go
@@ -71,6 +71,7 @@ type LedgerPath struct {
 // Verify ledger path correctness.
 // begin is lower block number and end is higher, opposite to how path is actually sorted.
 // This order makes it easier to the caller.
+// Please, keep in mind that Path of one single block is correct by definition
 func (lp *LedgerPath) Verify(begin, end *types.BlockHeader) (bool, error) {
 
 	if len(lp.Path) < 1 {


### PR DESCRIPTION
Fixed case then tx is part of last block, so second part of path in ledger doesn't exist

Signed-off-by: Gennady Laventman <gennady@il.ibm.com>