### PR TITLE
Cluster session gets updated status

### DIFF
--- a/internal/replica_set.go
+++ b/internal/replica_set.go
@@ -1,0 +1,96 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+
+	"github.com/hyperledger-labs/orion-server/pkg/types"
+	"github.com/pkg/errors"
+)
+
+type ReplicaRole int32
+
+const (
+	ReplicaRole_LEADER   ReplicaRole = 0
+	ReplicaRole_FOLLOWER ReplicaRole = 1
+	ReplicaRole_UNKNOWN  ReplicaRole = 2
+)
+
+var ReplicaRoleName = map[int32]string{
+	0: "LEADER",
+	1: "FOLLOWER",
+	2: "UNKNOWN",
+}
+
+var ReplicaRoleValue = map[string]int32{
+	"LEADER":   0,
+	"FOLLOWER": 1,
+	"UNKNOWN":  2,
+}
+
+type ReplicaWithRole struct {
+	Id   string
+	URL  *url.URL
+	Role ReplicaRole
+}
+
+func (r *ReplicaWithRole) String() string {
+	stateName, _ := ReplicaRoleName[int32(r.Role)]
+	return fmt.Sprintf("Id: %s, Role: %s, URL: %s", r.Id, stateName, r.URL.String())
+}
+
+type ReplicaSet []*ReplicaWithRole
+
+// SortByRole sort the replicas such that the leader is first, then followers, then unknown.
+func (r ReplicaSet) SortByRole() {
+	if r == nil {
+		return
+	}
+	sort.Slice(r, func(i, j int) bool { return r[i].Role < r[j].Role })
+}
+
+// ClusterStatusToReplicaSet creates a sorted array of ReplicaWithRole objects, leader first.
+func ClusterStatusToReplicaSet(clusterStatus *types.GetClusterStatusResponse, tlsEnabled bool) (ReplicaSet, error) {
+	if clusterStatus == nil {
+		return nil, errors.New("ClusterStatus is nil")
+	}
+
+	var replicas ReplicaSet
+
+	urlPattern := "http://%s:%d"
+	if tlsEnabled {
+		urlPattern = "https://%s:%d"
+	}
+	for _, node := range clusterStatus.Nodes {
+		parsedURL, err := url.ParseRequestURI(fmt.Sprintf(urlPattern, node.Address, node.Port))
+		if err != nil {
+			return nil, err
+		}
+		r := &ReplicaWithRole{
+			Id:   node.Id,
+			URL:  parsedURL,
+			Role: ReplicaRole_UNKNOWN,
+		}
+
+		if node.Id == clusterStatus.GetLeader() {
+			r.Role = ReplicaRole_LEADER
+		} else {
+			for _, active := range clusterStatus.GetActive() {
+				if node.Id == active {
+					r.Role = ReplicaRole_FOLLOWER
+					break
+				}
+			}
+		}
+
+		replicas = append(replicas, r)
+	}
+
+	replicas.SortByRole()
+
+	return replicas, nil
+}

--- a/internal/replica_set_test.go
+++ b/internal/replica_set_test.go
@@ -1,0 +1,168 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/hyperledger-labs/orion-server/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterStatusToReplicaSet(t *testing.T) {
+	nodes := testNodes(5)
+
+	t.Run("nil", func(t *testing.T) {
+		r, err := ClusterStatusToReplicaSet(nil, false)
+		require.EqualError(t, err, "ClusterStatus is nil")
+		require.Len(t, r, 0)
+		r.SortByRole() //does not throw
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		r, err := ClusterStatusToReplicaSet(&types.GetClusterStatusResponse{}, false)
+		require.NoError(t, err)
+		require.Len(t, r, 0)
+		r.SortByRole() //does not throw
+	})
+
+	t.Run("no leader", func(t *testing.T) {
+		clusterStatus := &types.GetClusterStatusResponse{
+			Header:  nil,
+			Nodes:   nodes,
+			Version: &types.Version{BlockNum: 1, TxNum: 0},
+			Leader:  "",
+			Active:  []string{"node-3", "node-5"},
+		}
+		r, err := ClusterStatusToReplicaSet(clusterStatus, false)
+		require.NoError(t, err)
+		require.Len(t, r, 5)
+
+		for i := 0; i < 5; i++ {
+			switch i {
+			case 0, 1:
+				require.Equal(t, ReplicaRole_FOLLOWER, r[i].Role)
+			default:
+				require.Equal(t, ReplicaRole_UNKNOWN, r[i].Role)
+			}
+		}
+	})
+
+	t.Run("with leader", func(t *testing.T) {
+		clusterStatus := &types.GetClusterStatusResponse{
+			Header:  nil,
+			Nodes:   nodes,
+			Version: &types.Version{BlockNum: 1, TxNum: 0},
+			Leader:  "node-1",
+			Active:  []string{"node-1", "node-2", "node-3"},
+		}
+		r, err := ClusterStatusToReplicaSet(clusterStatus, false)
+		require.NoError(t, err)
+		require.Len(t, r, 5)
+
+		for i := 0; i < 5; i++ {
+			switch i {
+			case 0:
+				require.Equal(t, ReplicaRole_LEADER, r[i].Role)
+			case 1, 2:
+				require.Equal(t, ReplicaRole_FOLLOWER, r[i].Role)
+			default:
+				require.Equal(t, ReplicaRole_UNKNOWN, r[i].Role)
+			}
+		}
+	})
+
+	t.Run("with leader unordered", func(t *testing.T) {
+		clusterStatus := &types.GetClusterStatusResponse{
+			Header:  nil,
+			Nodes:   nodes,
+			Version: &types.Version{BlockNum: 1, TxNum: 0},
+			Leader:  "node-5",
+			Active:  []string{"node-1", "node-3", "node-5"},
+		}
+		r, err := ClusterStatusToReplicaSet(clusterStatus, false)
+		require.NoError(t, err)
+		require.Len(t, r, 5)
+
+		for i := 0; i < 5; i++ {
+			switch i {
+			case 0:
+				require.Equal(t, ReplicaRole_LEADER, r[i].Role)
+			case 1, 2:
+				require.Equal(t, ReplicaRole_FOLLOWER, r[i].Role)
+			default:
+				require.Equal(t, ReplicaRole_UNKNOWN, r[i].Role)
+			}
+		}
+	})
+
+	t.Run("bad url", func(t *testing.T) {
+		clusterStatus := &types.GetClusterStatusResponse{
+			Header:  nil,
+			Nodes:   nodes,
+			Version: &types.Version{BlockNum: 1, TxNum: 0},
+			Leader:  "node-1",
+			Active:  []string{"node-1", "node-2", "node-3"},
+		}
+		clusterStatus.Nodes[0].Address = "127.%JK.1" //bad
+		r, err := ClusterStatusToReplicaSet(clusterStatus, false)
+		require.EqualError(t, err, "parse \"http://127.%JK.1:6001\": invalid URL escape \"%JK\"")
+		require.Nil(t, r)
+	})
+}
+
+func TestReplicaSet_SortByRole(t *testing.T) {
+	r := make(ReplicaSet, 5)
+	r[0] = &ReplicaWithRole{Role: ReplicaRole_UNKNOWN}
+	r[1] = &ReplicaWithRole{Role: ReplicaRole_FOLLOWER}
+	r[2] = &ReplicaWithRole{Role: ReplicaRole_FOLLOWER}
+	r[3] = &ReplicaWithRole{Role: ReplicaRole_FOLLOWER}
+	r[4] = &ReplicaWithRole{Role: ReplicaRole_LEADER}
+
+	r.SortByRole()
+
+	for i := 0; i < 5; i++ {
+		switch i {
+		case 0:
+			require.Equal(t, ReplicaRole_LEADER, r[i].Role)
+		case 1, 2, 3:
+			require.Equal(t, ReplicaRole_FOLLOWER, r[i].Role)
+		default:
+			require.Equal(t, ReplicaRole_UNKNOWN, r[i].Role)
+		}
+	}
+}
+
+func TestReplicaWithRole_String(t *testing.T) {
+	url, _ := url.Parse("http://10.10.10.10:9999")
+	r := &ReplicaWithRole{
+		Id:   "node",
+		URL:  url,
+		Role: ReplicaRole_UNKNOWN,
+	}
+	require.Equal(t, "Id: node, Role: UNKNOWN, URL: http://10.10.10.10:9999", r.String())
+	r.Role = ReplicaRole_FOLLOWER
+	require.Equal(t, "Id: node, Role: FOLLOWER, URL: http://10.10.10.10:9999", r.String())
+	r.Role = ReplicaRole_LEADER
+	require.Equal(t, "Id: node, Role: LEADER, URL: http://10.10.10.10:9999", r.String())
+
+}
+
+func testNodes(num uint32) []*types.NodeConfig {
+	var nodes []*types.NodeConfig
+	for i := uint32(1); i <= num; i++ {
+		nodes = append(nodes,
+			&types.NodeConfig{
+				Id:          fmt.Sprintf("node-%d", i),
+				Address:     "10.10.10.10",
+				Port:        6000 + i,
+				Certificate: []byte("bogus"),
+			},
+		)
+	}
+
+	return nodes
+}

--- a/pkg/bcdb/dbs_tx_context_test.go
+++ b/pkg/bcdb/dbs_tx_context_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger-labs/orion-sdk-go/internal"
 	"github.com/hyperledger-labs/orion-sdk-go/pkg/bcdb/mocks"
 	sdkConfig "github.com/hyperledger-labs/orion-sdk-go/pkg/config"
 	"github.com/hyperledger-labs/orion-server/pkg/server/testutils"
@@ -314,7 +315,8 @@ func TestDBsContext_MalformedRequest(t *testing.T) {
 		},
 	})
 	require.Error(t, err)
-	require.EqualError(t, err, "cannot create a signature verifier: failed to obtain the servers' certificates")
+	expectedErr := fmt.Sprintf("cannot update the replica set and signature verifier: failed to obtain the latest cluster status: failed to get cluster status from replica set: [Id: testNode1, Role: UNKNOWN, URL: http://localhost:%s]; version: <nil>, last error: error response from the server, 401 Unauthorized", serverPort)
+	require.EqualError(t, err, expectedErr)
 }
 
 func TestDBsContext_ExistsFailureScenarios(t *testing.T) {
@@ -361,10 +363,8 @@ func TestDBsContext_ExistsFailureScenarios(t *testing.T) {
 					userID:     "testUserId",
 					restClient: restClient,
 					logger:     logger,
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 				},
 				createdDBs: map[string]*types.DBIndex{},

--- a/pkg/bcdb/session_test.go
+++ b/pkg/bcdb/session_test.go
@@ -1,0 +1,176 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package bcdb
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/orion-sdk-go/internal"
+	sdkconfig "github.com/hyperledger-labs/orion-sdk-go/pkg/config"
+	"github.com/hyperledger-labs/orion-server/pkg/server/testutils"
+	"github.com/hyperledger-labs/orion-server/pkg/types"
+	"github.com/hyperledger-labs/orion-server/test/setup"
+	"github.com/stretchr/testify/require"
+)
+
+// Scenario: replica set gets updated when a new session is created.
+// - start a 3 node cluster
+// - db instance with a partial bootstrap
+// - create a session
+// - db instance with a full bootstrap
+// - creat a session
+// - shutdown leader
+// - create a session
+func TestDbSession_UpdateReplicaSet(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cluster-test")
+	require.NoError(t, err)
+
+	nPort := uint32(6581)
+	pPort := uint32(6681)
+	setupConfig := &setup.Config{
+		NumberOfServers:     3,
+		TestDirAbsolutePath: dir,
+		BDBBinaryPath:       "../../bin/bdb",
+		CmdTimeout:          10 * time.Second,
+		BaseNodePort:        nPort,
+		BasePeerPort:        pPort,
+	}
+	c, err := setup.NewCluster(setupConfig)
+	require.NoError(t, err)
+	defer c.ShutdownAndCleanup()
+
+	require.NoError(t, c.Start())
+	leader := -1
+	require.Eventually(t, func() bool {
+		leader = c.AgreedLeader(t, 0, 1, 2)
+		return leader >= 0
+	}, 30*time.Second, time.Second)
+
+	// With a partial bootstrap replica set
+	connConfig := &sdkconfig.ConnectionConfig{
+		RootCAs: []string{path.Join(setupConfig.TestDirAbsolutePath, "ca", testutils.RootCAFileName+".pem")},
+		ReplicaSet: []*sdkconfig.Replica{
+			{
+				ID:       c.Servers[0].ID(),
+				Endpoint: c.Servers[0].URL(),
+			},
+		},
+	}
+
+	bcdb, err := Create(connConfig)
+	require.NoError(t, err)
+	require.NotNil(t, bcdb)
+
+	session := openUserSession(t, bcdb, "admin", path.Join(setupConfig.TestDirAbsolutePath, "users"))
+	sessionImpl := session.(*dbSession)
+	require.Len(t, sessionImpl.replicaSet, 3)
+	require.Equal(t, internal.ReplicaRole_LEADER, sessionImpl.replicaSet[0].Role)
+	require.Equal(t, internal.ReplicaRole_FOLLOWER, sessionImpl.replicaSet[1].Role)
+	require.Equal(t, internal.ReplicaRole_FOLLOWER, sessionImpl.replicaSet[2].Role)
+
+	// With a full bootstrap replica set
+	connConfig = &sdkconfig.ConnectionConfig{
+		RootCAs: []string{path.Join(setupConfig.TestDirAbsolutePath, "ca", testutils.RootCAFileName+".pem")},
+		ReplicaSet: []*sdkconfig.Replica{
+			{
+				ID:       c.Servers[0].ID(),
+				Endpoint: c.Servers[0].URL(),
+			},
+			{
+				ID:       c.Servers[1].ID(),
+				Endpoint: c.Servers[1].URL(),
+			},
+			{
+				ID:       c.Servers[2].ID(),
+				Endpoint: c.Servers[2].URL(),
+			},
+		},
+	}
+
+	bcdb, err = Create(connConfig)
+	require.NoError(t, err)
+	require.NotNil(t, bcdb)
+
+	session = openUserSession(t, bcdb, "admin", path.Join(setupConfig.TestDirAbsolutePath, "users"))
+	sessionImpl = session.(*dbSession)
+	require.Len(t, sessionImpl.replicaSet, 3)
+	require.Equal(t, internal.ReplicaRole_LEADER, sessionImpl.replicaSet[0].Role)
+	require.Equal(t, internal.ReplicaRole_FOLLOWER, sessionImpl.replicaSet[1].Role)
+	require.Equal(t, internal.ReplicaRole_FOLLOWER, sessionImpl.replicaSet[2].Role)
+
+	// Replica set updates on a new session with status of cluster - change of leader
+	require.NoError(t, c.ShutdownServer(c.Servers[leader]))
+	newLeader := -1
+	require.Eventually(t, func() bool {
+		newLeader = c.AgreedLeader(t, (leader+1)%3, (leader+2)%3)
+		return (newLeader >= 0) && (newLeader != leader)
+	}, 30*time.Second, time.Second)
+
+	session = openUserSession(t, bcdb, "admin", path.Join(setupConfig.TestDirAbsolutePath, "users"))
+	sessionImpl = session.(*dbSession)
+	require.Len(t, sessionImpl.replicaSet, 3)
+	require.Equal(t, internal.ReplicaRole_LEADER, sessionImpl.replicaSet[0].Role)
+	require.Equal(t, internal.ReplicaRole_FOLLOWER, sessionImpl.replicaSet[1].Role)
+	require.Equal(t, internal.ReplicaRole_UNKNOWN, sessionImpl.replicaSet[2].Role)
+}
+
+func TestDbSession_compareVersion(t *testing.T) {
+	type testCase struct {
+		x        *types.Version
+		y        *types.Version
+		expected int
+	}
+
+	for i, tc := range []testCase{
+		{
+			x:        nil,
+			y:        nil,
+			expected: 0,
+		},
+		{
+			x:        nil,
+			y:        &types.Version{},
+			expected: 0,
+		},
+		{
+			x:        &types.Version{},
+			y:        &types.Version{},
+			expected: 0,
+		},
+		{
+			x:        &types.Version{BlockNum: 8, TxNum: 5},
+			y:        &types.Version{BlockNum: 8, TxNum: 5},
+			expected: 0,
+		},
+		{
+			x:        &types.Version{BlockNum: 9, TxNum: 4},
+			y:        &types.Version{BlockNum: 8, TxNum: 5},
+			expected: 1,
+		},
+		{
+			x:        &types.Version{BlockNum: 9, TxNum: 5},
+			y:        &types.Version{BlockNum: 8, TxNum: 5},
+			expected: 1,
+		},
+		{
+			x:        &types.Version{BlockNum: 9, TxNum: 6},
+			y:        &types.Version{BlockNum: 8, TxNum: 5},
+			expected: 1,
+		},
+		{
+			x:        &types.Version{BlockNum: 8, TxNum: 6},
+			y:        &types.Version{BlockNum: 8, TxNum: 5},
+			expected: 1,
+		},
+	} {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			require.Equal(t, tc.expected, compareVersion(tc.x, tc.y))
+			require.Equal(t, -1*tc.expected, compareVersion(tc.y, tc.x))
+		})
+	}
+}

--- a/pkg/bcdb/tls_test.go
+++ b/pkg/bcdb/tls_test.go
@@ -122,7 +122,8 @@ func TestSessionWithoutServerTLSAndWithClientTLS(t *testing.T) {
 	// New session with admin user context
 	_, err = openUserSessionWithQueryTimeoutAndTLS(bcdb, "admin", certTempDir, 0, true)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot create a signature verifier: failed to obtain the servers' certificates")
+	require.Contains(t, err.Error(), "cannot update the replica set and signature verifier: failed to obtain the latest cluster status: failed to get cluster status from replica set: [Id: testNode1, Role: UNKNOWN, URL:")
+	require.Contains(t, err.Error(), "http: server gave HTTP response to HTTPS client")
 }
 
 func TestSessionWithServerTLSAndNotConfiguredClient(t *testing.T) {
@@ -139,7 +140,8 @@ func TestSessionWithServerTLSAndNotConfiguredClient(t *testing.T) {
 	// New session with admin user context
 	_, err = openUserSessionWithQueryTimeoutAndTLS(bcdb, "admin", certTempDir, 0, true)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot create a signature verifier: failed to obtain the servers' certificates")
+	require.Contains(t, err.Error(), "cannot update the replica set and signature verifier: failed to obtain the latest cluster status: failed to get cluster status from replica set: [Id: testNode1, Role: UNKNOWN, URL:")
+	require.Contains(t, err.Error(), "error response from the server, 400 Bad Request")
 }
 
 func TestSessionServerTLSAndClientTLSIncorrectClientCA(t *testing.T) {
@@ -156,7 +158,7 @@ func TestSessionServerTLSAndClientTLSIncorrectClientCA(t *testing.T) {
 	// New session with admin user context
 	_, err = openUserSessionWithQueryTimeoutAndTLS(bcdb, "admin", certTempDir, 0, true)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot create a signature verifier: failed to obtain the servers' certificates")
+	require.Contains(t, err.Error(), "cannot update the replica set and signature verifier: failed to obtain the latest cluster status: failed to get cluster status from replica set: [Id: testNode1, Role: UNKNOWN, URL:")
 }
 
 func TestSessionServerTLSNoClientTLSIncorrectCAOnClientSide(t *testing.T) {
@@ -173,7 +175,8 @@ func TestSessionServerTLSNoClientTLSIncorrectCAOnClientSide(t *testing.T) {
 	// New session with admin user context
 	_, err = openUserSessionWithQueryTimeoutAndTLS(bcdb, "admin", certTempDir, 0, false)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot create a signature verifier: failed to obtain the servers' certificates")
+	require.Contains(t, err.Error(), "cannot update the replica set and signature verifier: failed to obtain the latest cluster status: failed to get cluster status from replica set: [Id: testNode1, Role: UNKNOWN, URL:")
+	require.Contains(t, err.Error(), "x509: certificate signed by unknown authority")
 }
 
 // Generates correct TLS CA certificate for server, correct TLS server certificates, but client side TLS certificates signed by incorrect CA

--- a/pkg/bcdb/tx_context_test.go
+++ b/pkg/bcdb/tx_context_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger-labs/orion-sdk-go/internal"
 	"github.com/hyperledger-labs/orion-sdk-go/pkg/bcdb/mocks"
 	"github.com/hyperledger-labs/orion-server/pkg/constants"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
@@ -45,10 +46,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -67,10 +66,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -90,10 +87,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -114,10 +109,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -139,12 +132,9 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
-					},
-					verifier: verifier,
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
+					}, verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
 						process: syncSubmit,
 						resp:    serverTimeoutResponse(),
@@ -164,10 +154,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -187,10 +175,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifierFails,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -210,10 +196,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -233,10 +217,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -258,10 +240,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -284,10 +264,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifierFails,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -308,10 +286,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -330,10 +306,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -354,10 +328,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -379,10 +351,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifierFails,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -402,10 +372,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -424,10 +392,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -448,10 +414,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifier,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -473,10 +437,8 @@ func TestTxCommit(t *testing.T) {
 					userID:   "testUser",
 					signer:   emptySigner,
 					userCert: []byte{1, 2, 3},
-					replicaSet: map[string]*url.URL{
-						"node1": {
-							Path: "http://localhost:8888",
-						},
+					replicaSet: []*internal.ReplicaWithRole{
+						{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 					},
 					verifier: verifierFails,
 					restClient: NewRestClient("testUser", &mockHttpClient{
@@ -539,10 +501,8 @@ func TestTxQuery(t *testing.T) {
 				userID:   "testUser",
 				signer:   emptySigner,
 				userCert: []byte{1, 2, 3},
-				replicaSet: map[string]*url.URL{
-					"node1": {
-						Path: "http://localhost:8888",
-					},
+				replicaSet: []*internal.ReplicaWithRole{
+					{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 				},
 				verifier: verifier,
 				restClient: NewRestClient("testUser", &mockHttpClient{
@@ -560,10 +520,8 @@ func TestTxQuery(t *testing.T) {
 				userID:   "testUser",
 				signer:   emptySigner,
 				userCert: []byte{1, 2, 3},
-				replicaSet: map[string]*url.URL{
-					"node1": {
-						Path: "http://localhost:8888",
-					},
+				replicaSet: []*internal.ReplicaWithRole{
+					{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 				},
 				verifier: verifier,
 				restClient: NewRestClient("testUser", &mockHttpClient{
@@ -582,10 +540,8 @@ func TestTxQuery(t *testing.T) {
 				userID:   "testUser",
 				signer:   emptySigner,
 				userCert: []byte{1, 2, 3},
-				replicaSet: map[string]*url.URL{
-					"node1": {
-						Path: "http://localhost:8888",
-					},
+				replicaSet: []*internal.ReplicaWithRole{
+					{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 				},
 				verifier: verifier,
 				restClient: NewRestClient("testUser", &mockHttpClient{
@@ -603,10 +559,8 @@ func TestTxQuery(t *testing.T) {
 				userID:   "testUser",
 				signer:   emptySigner,
 				userCert: []byte{1, 2, 3},
-				replicaSet: map[string]*url.URL{
-					"node1": {
-						Path: "http://localhost:8888",
-					},
+				replicaSet: []*internal.ReplicaWithRole{
+					{Id: "node1", URL: &url.URL{Path: "http://localhost:8888"}, Role: internal.ReplicaRole_LEADER},
 				},
 				verifier: verifierFails,
 				restClient: NewRestClient("testUser", &mockHttpClient{

--- a/pkg/bcdb/util_test.go
+++ b/pkg/bcdb/util_test.go
@@ -196,7 +196,7 @@ func createTestLogger(t *testing.T) *logger.SugarLogger {
 		OutputPath:    []string{"stdout"},
 		ErrOutputPath: []string{"stderr"},
 		Encoding:      "console",
-		Name:          "bcdb-client",
+		Name:          "orion-client",
 	}
 	logger, err := logger.New(c)
 	require.NoError(t, err)
@@ -252,6 +252,7 @@ func createDBInstanceWithTLSConfig(t *testing.T, cryptoDir string, serverPort st
 				Endpoint: fmt.Sprintf("http://localhost:%s", serverPort),
 			},
 		},
+		Logger: createTestLogger(t),
 	}
 	updateClientConfig(t, cryptoDir, serverPort, conf, tlsEnabled, clientTLSRequired)
 	bcdb, err := Create(conf)


### PR DESCRIPTION
When creating a session, get the most updated cluster status.
This allows the session to use the bootstrap-replica-set and get the full list of nodes and their status.