### PR TITLE
group reads/writes provenance response by db

### DIFF
--- a/examples/api/provenance/provenance.go
+++ b/examples/api/provenance/provenance.go
@@ -137,8 +137,10 @@ func executeProvenanceExample(cryptoDir string, configFile string) error {
 		return err
 	}
 	fmt.Println("All user reads for user alice are:")
-	for i := 0; i < len(res5); i++ {
-		fmt.Printf("value: %s, version: %s\n", res5[i].GetValue(), res5[i].GetMetadata().GetVersion())
+	for dbName, reads := range res5 {
+		for _, kv := range reads.KVs {
+			fmt.Printf("dbname: %s, key: %s, value: %s, version: %s\n", dbName, kv.GetKey(), kv.GetValue(), kv.GetMetadata().GetVersion())
+		}
 	}
 
 	fmt.Println("Getting all user writes for user alice")
@@ -148,8 +150,10 @@ func executeProvenanceExample(cryptoDir string, configFile string) error {
 		return err
 	}
 	fmt.Println("All user writes for user alice are:")
-	for i := 0; i < len(res6); i++ {
-		fmt.Printf("value: %s, version: %s\n", res6[i].GetValue(), res6[i].GetMetadata().GetVersion())
+	for dbName, writes := range res6 {
+		for _, kv := range writes.KVs {
+			fmt.Printf("dbname: %s, key: %s, value: %s, version: %s\n", dbName, kv.GetKey(), kv.GetValue(), kv.GetMetadata().GetVersion())
+		}
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/hyperledger-labs/orion-server v0.2.3-0.20220315123754-bee453356e8b
+	github.com/hyperledger-labs/orion-server v0.2.4-0.20220531080909-badd4d7bb1f5
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,10 @@ github.com/hyperledger-labs/orion-server v0.2.2 h1:w8zAzxWfCI4+3yPs190DlSd68CNMI
 github.com/hyperledger-labs/orion-server v0.2.2/go.mod h1:8kXVAU1wvFYGbFL1qmXwMi2i8gKV2smOdp1F1kq0HMk=
 github.com/hyperledger-labs/orion-server v0.2.3-0.20220315123754-bee453356e8b h1:Z3LA2w6PLqJZh2qpEf4WZoKOg+K4ry/haDCWEVvdLg0=
 github.com/hyperledger-labs/orion-server v0.2.3-0.20220315123754-bee453356e8b/go.mod h1:8kXVAU1wvFYGbFL1qmXwMi2i8gKV2smOdp1F1kq0HMk=
+github.com/hyperledger-labs/orion-server v0.2.3 h1:vY9IQRO2sHdWUwLNKz6J7x+kZJXYLmTU3z3GLLWSTpQ=
+github.com/hyperledger-labs/orion-server v0.2.3/go.mod h1:8kXVAU1wvFYGbFL1qmXwMi2i8gKV2smOdp1F1kq0HMk=
+github.com/hyperledger-labs/orion-server v0.2.4-0.20220531080909-badd4d7bb1f5 h1:qy4M67EISCrlmCmH1ePY0PPVXDoUKHL9Ir9pGQzZULg=
+github.com/hyperledger-labs/orion-server v0.2.4-0.20220531080909-badd4d7bb1f5/go.mod h1:8kXVAU1wvFYGbFL1qmXwMi2i8gKV2smOdp1F1kq0HMk=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pkg/bcdb/db.go
+++ b/pkg/bcdb/db.go
@@ -102,10 +102,10 @@ type Provenance interface {
 	GetPreviousHistoricalData(dbName, key string, version *types.Version) ([]*types.ValueWithMetadata, error)
 	// GetNextHistoricalData returns value succeeds given version, including its metadata
 	GetNextHistoricalData(dbName, key string, version *types.Version) ([]*types.ValueWithMetadata, error)
-	// GetDataReadByUser returns all user reads
-	GetDataReadByUser(userID string) ([]*types.KVWithMetadata, error)
-	// GetDataWrittenByUser returns all user writes
-	GetDataWrittenByUser(userID string) ([]*types.KVWithMetadata, error)
+	// GetDataReadByUser returns all user reads grouped by databases
+	GetDataReadByUser(userID string) (map[string]*types.KVsWithMetadata, error)
+	// GetDataWrittenByUser returns all user writes grouped by databases
+	GetDataWrittenByUser(userID string) (map[string]*types.KVsWithMetadata, error)
 	// GetReaders returns all users who read value associated with the key
 	GetReaders(dbName, key string) ([]string, error)
 	// GetWriters returns all users who wrote value associated with the key
@@ -236,7 +236,7 @@ func Create(connectionConfig *config.ConnectionConfig) (BCDB, error) {
 }
 
 type bDB struct {
-	mutex               sync.Mutex
+	mutex                sync.Mutex
 	bootstrapReplicaMap  map[string]*url.URL
 	rootCAs              *certificateauthority.CACertCollection
 	tlsEnabled           bool

--- a/pkg/bcdb/provenance.go
+++ b/pkg/bcdb/provenance.go
@@ -98,7 +98,7 @@ func (p *provenance) GetNextHistoricalData(dbName, key string, version *types.Ve
 	return resEnv.GetResponse().GetValues(), nil
 }
 
-func (p *provenance) GetDataReadByUser(userID string) ([]*types.KVWithMetadata, error) {
+func (p *provenance) GetDataReadByUser(userID string) (map[string]*types.KVsWithMetadata, error) {
 	path := constants.URLForGetDataReadBy(userID)
 	resEnv := &types.GetDataProvenanceResponseEnvelope{}
 	err := p.handleRequest(
@@ -112,10 +112,10 @@ func (p *provenance) GetDataReadByUser(userID string) ([]*types.KVWithMetadata, 
 		p.logger.Errorf("failed to execute data read by user query %s, due to %s", path, err)
 		return nil, err
 	}
-	return resEnv.GetResponse().GetKVs(), nil
+	return resEnv.GetResponse().GetDBKeyValues(), nil
 }
 
-func (p *provenance) GetDataWrittenByUser(userID string) ([]*types.KVWithMetadata, error) {
+func (p *provenance) GetDataWrittenByUser(userID string) (map[string]*types.KVsWithMetadata, error) {
 	path := constants.URLForGetDataWrittenBy(userID)
 	resEnv := &types.GetDataProvenanceResponseEnvelope{}
 	err := p.handleRequest(
@@ -130,7 +130,7 @@ func (p *provenance) GetDataWrittenByUser(userID string) ([]*types.KVWithMetadat
 		return nil, err
 	}
 
-	return resEnv.GetResponse().GetKVs(), nil
+	return resEnv.GetResponse().GetDBKeyValues(), nil
 }
 
 func (p *provenance) GetReaders(dbName, key string) ([]string, error) {

--- a/pkg/bcdb/provenance_test.go
+++ b/pkg/bcdb/provenance_test.go
@@ -397,14 +397,16 @@ func TestReadWriteAccessBytUserAndKey(t *testing.T) {
 			keys := make([]string, 0)
 			reads, err := p.GetDataReadByUser(tt.user)
 			require.NoError(t, err)
-			for _, k := range reads {
+			require.Len(t, reads, 1)
+			for _, k := range reads["bdb"].GetKVs() {
 				keys = append(keys, k.GetKey())
 			}
 			require.ElementsMatch(t, tt.readKeys, keys)
 			keys = make([]string, 0)
 			writes, err := p.GetDataWrittenByUser(tt.user)
 			require.NoError(t, err)
-			for _, k := range writes {
+			require.Len(t, writes, 1)
+			for _, k := range writes["bdb"].GetKVs() {
 				keys = append(keys, k.GetKey())
 			}
 			require.ElementsMatch(t, tt.writtenKeys, keys)


### PR DESCRIPTION
For GetValuesReadBy() and GetValuesWritten() APIs,
we have to group keys by databases. In the past, there
was a bug at the server which did not group keys by databases.
As now the bug has been fixed at the server side, we are
updating the client APIs in this commit.

Signed-off-by: senthil <cendhu@gmail.com>