### PR TITLE
Encode keys in URLs with base64url raw & User ACL

### DIFF
--- a/examples/cars/commands/init.go
+++ b/examples/cars/commands/init.go
@@ -155,10 +155,7 @@ func initUsers(demoDir string, session bcdb.DBSession, logger *logger.SugarLogge
 				Privilege: &types.Privilege{
 					DbPermission: map[string]types.Privilege_Access{CarDBName: 1},
 				},
-			}, &types.AccessControl{
-				ReadWriteUsers: usersMap("admin"),
-				ReadUsers:      usersMap("admin"),
-			})
+			}, nil)
 		if err != nil {
 			usersTx.Abort()
 			return err

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/hyperledger-labs/orion-server v0.2.8-0.20221227114951-121fcc6e6da9
+	github.com/hyperledger-labs/orion-server v0.2.8-0.20230102160324-1c8af68de569
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -361,8 +361,8 @@ github.com/hyperledger-labs/orion-server v0.2.6-0.20220828084308-c4591bc4f62e h1
 github.com/hyperledger-labs/orion-server v0.2.6-0.20220828084308-c4591bc4f62e/go.mod h1:2r+yOJL1a7r/ZZbc1t0LDhT3fRSv1WcQ33OLh/dHIuw=
 github.com/hyperledger-labs/orion-server v0.2.7 h1:H7V2cBb2YRSd4ph3zJl9/Ljz6Qyuk0SL2mNriImTdk0=
 github.com/hyperledger-labs/orion-server v0.2.7/go.mod h1:2r+yOJL1a7r/ZZbc1t0LDhT3fRSv1WcQ33OLh/dHIuw=
-github.com/hyperledger-labs/orion-server v0.2.8-0.20221227114951-121fcc6e6da9 h1:d8mRz0Cevfw+YF+urzhx7geL1b3R9I8/Bw4BSxwibck=
-github.com/hyperledger-labs/orion-server v0.2.8-0.20221227114951-121fcc6e6da9/go.mod h1:2r+yOJL1a7r/ZZbc1t0LDhT3fRSv1WcQ33OLh/dHIuw=
+github.com/hyperledger-labs/orion-server v0.2.8-0.20230102160324-1c8af68de569 h1:xGuFURtpPmvJXmpmjxqUcY0ZJvWFUcKDKeuiEvOETHw=
+github.com/hyperledger-labs/orion-server v0.2.8-0.20230102160324-1c8af68de569/go.mod h1:DMM9+Ytsqna9ji/N5EcCc2i+FQsTuIF35zq472CvIe4=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pkg/bcdb/data_tx_context_test.go
+++ b/pkg/bcdb/data_tx_context_test.go
@@ -343,7 +343,7 @@ func TestDataContext_GetUserPermissions(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = tx.Get("bdb", "key1")
 	require.Error(t, err)
-	require.EqualError(t, err, "error handling request, server returned: status: 403 Forbidden, status code: 403, message: error while processing 'GET /data/bdb/key1' because the user [bob] has no permission to read key [key1] from database [bdb]")
+	require.EqualError(t, err, "error handling request, server returned: status: 403 Forbidden, status code: 403, message: error while processing 'GET /data/bdb/a2V5MQ' because the user [bob] has no permission to read key [key1] from database [bdb]")
 	err = tx.Abort()
 	require.NoError(t, err)
 

--- a/pkg/bcdb/ledger_test.go
+++ b/pkg/bcdb/ledger_test.go
@@ -380,7 +380,7 @@ func TestGetStateProof(t *testing.T) {
 			key:        "key6_1",
 			value:      []byte("value6_1"),
 			isDeleted:  false,
-			errMessage: "404 Not Found, status code: 404, message: error while processing 'GET /ledger/proof/data/bdb/key6_1?block=19' because block not found: 19",
+			errMessage: "404 Not Found, status code: 404, message: error while processing 'GET /ledger/proof/data/bdb/a2V5Nl8x?block=19' because block not found: 19",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- Encode keys in URLs with base64url raw
- Fix user management ACL logic per new design

Signed-off-by: Yoav Tock <tock@il.ibm.com>